### PR TITLE
Handle image generation errors

### DIFF
--- a/lib/line-bot-cdk.function.ts
+++ b/lib/line-bot-cdk.function.ts
@@ -137,11 +137,18 @@ export const handler = async (event: APIGatewayEvent, _context: Context): Promis
     await Promise.all(events.map(async (ev) => {
       if (ev.type === 'message' && ev.message.type === 'text') {
         if (isImageRequest(ev.message.text)) {
-          const url = await generateImages(ev.message.text, clients.openaiClient);
-          await clients.lineClient.replyMessage({
-            replyToken: ev.replyToken,
-            messages: [{ type: 'image', originalContentUrl: url, previewImageUrl: url }]
-          });
+          try {
+            const url = await generateImages(ev.message.text, clients.openaiClient);
+            await clients.lineClient.replyMessage({
+              replyToken: ev.replyToken,
+              messages: [{ type: 'image', originalContentUrl: url, previewImageUrl: url }]
+            });
+          } catch (error: any) {
+            await clients.lineClient.replyMessage({
+              replyToken: ev.replyToken,
+              messages: [{ type: 'text', text: `画像生成に失敗しました: ${error.message}` }]
+            });
+          }
         } else {
           const reply = await askOpenAI(ev.message.text, clients.openaiClient);
           await clients.lineClient.replyMessage({


### PR DESCRIPTION
## Summary
- handle `generateImages` errors so LINE users are notified when image creation fails

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68481ab8b7788320be4ed060a81f225f