### PR TITLE
Restore npm install instruction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      EMAIL_ADDRESS: ${{ vars.EMAIL_ADDRESS }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/test/line-bot-cdk.test.ts
+++ b/test/line-bot-cdk.test.ts
@@ -7,6 +7,8 @@ import { LineBotCdkStack } from '../lib/line-bot-cdk-stack';
 
 test('Stack has a Lambda function', () => {
   const app = new cdk.App();
+  // Provide a dummy email so the stack can create the SNS subscription
+  process.env.EMAIL_ADDRESS = 'test@example.com';
   const stack = new LineBotCdkStack(app, 'TestStack');
   const template = Template.fromStack(stack);
   const functions = template.findResources('AWS::Lambda::Function');

--- a/test/line-bot-cdk.test.ts
+++ b/test/line-bot-cdk.test.ts
@@ -1,17 +1,14 @@
-// import * as cdk from 'aws-cdk-lib';
-// import { Template } from 'aws-cdk-lib/assertions';
-// import * as LineBotCdk from '../lib/line-bot-cdk-stack';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { LineBotCdkStack } from '../lib/line-bot-cdk-stack';
 
-// example test. To run these tests, uncomment this file along with the
-// example resource in lib/line-bot-cdk-stack.ts
-test('SQS Queue Created', () => {
-//   const app = new cdk.App();
-//     // WHEN
-//   const stack = new LineBotCdk.LineBotCdkStack(app, 'MyTestStack');
-//     // THEN
-//   const template = Template.fromStack(stack);
+// Test that the stack defines at least one Lambda function
+// This ensures the LineBot construct is synthesized correctly
 
-//   template.hasResourceProperties('AWS::SQS::Queue', {
-//     VisibilityTimeout: 300
-//   });
+test('Stack has a Lambda function', () => {
+  const app = new cdk.App();
+  const stack = new LineBotCdkStack(app, 'TestStack');
+  const template = Template.fromStack(stack);
+  const functions = template.findResources('AWS::Lambda::Function');
+  expect(Object.keys(functions).length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- restore the `npm install` step in the README deploy instructions
- keep Lambda function synthesis test and CI workflow
- allow manual workflow dispatch

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848441e4dc483209358c6f15549ff3d