### PR TITLE
Fix test env and workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      CHANNEL_SECRET_PARAM_NAME: ${{ vars.CHANNEL_SECRET_PARAM_NAME }}
+      CHANNEL_ACCESS_TOKEN_PARAM_NAME: ${{ vars.CHANNEL_ACCESS_TOKEN_PARAM_NAME }}
+      OPENAI_API_KEY_PARAM_NAME: ${{ vars.OPENAI_API_KEY_PARAM_NAME }}
       EMAIL_ADDRESS: ${{ vars.EMAIL_ADDRESS }}
     steps:
       - uses: actions/checkout@v3

--- a/test/line-bot-cdk.test.ts
+++ b/test/line-bot-cdk.test.ts
@@ -7,7 +7,10 @@ import { LineBotCdkStack } from '../lib/line-bot-cdk-stack';
 
 test('Stack has a Lambda function', () => {
   const app = new cdk.App();
-  // Provide a dummy email so the stack can create the SNS subscription
+  // Provide dummy environment variables so the stack can be instantiated
+  process.env.CHANNEL_SECRET_PARAM_NAME = 'dummySecretParam';
+  process.env.CHANNEL_ACCESS_TOKEN_PARAM_NAME = 'dummyAccessTokenParam';
+  process.env.OPENAI_API_KEY_PARAM_NAME = 'dummyOpenAIApiKeyParam';
   process.env.EMAIL_ADDRESS = 'test@example.com';
   const stack = new LineBotCdkStack(app, 'TestStack');
   const template = Template.fromStack(stack);


### PR DESCRIPTION
## Summary
- update GitHub Actions test workflow with required environment vars
- set dummy env vars in unit test so tests run locally

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872788389ec8320bfb4d94a51d1fce7