### PR TITLE
Remove redundant OpenAI model test

### DIFF
--- a/test/line-bot-cdk.test.ts
+++ b/test/line-bot-cdk.test.ts
@@ -1,8 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { LineBotCdkStack } from '../lib/line-bot-cdk-stack';
-import * as fs from 'fs';
-import * as path from 'path';
 
 // Test that the stack defines at least one Lambda function
 // This ensures the LineBot construct is synthesized correctly
@@ -20,11 +18,3 @@ test('Stack has a Lambda function', () => {
   expect(Object.keys(functions).length).toBeGreaterThan(0);
 });
 
-test('Lambda function uses correct OpenAI model', () => {
-  // Read the Lambda function source code
-  const functionPath = path.join(__dirname, '../lib/line-bot-cdk.function.ts');
-  const functionCode = fs.readFileSync(functionPath, 'utf8');
-  
-  // Verify that the MODEL_NAME is set to gpt-5-mini
-  expect(functionCode).toContain('const MODEL_NAME = "gpt-5-mini";');
-});


### PR DESCRIPTION
## Summary
- drop extraneous unit test checking for a specific OpenAI model constant

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897f376777c8320bca0ebec7c1b6928