### PR TITLE
feat: use dall-e-3 for images

### DIFF
--- a/lib/line-bot-cdk.function.ts
+++ b/lib/line-bot-cdk.function.ts
@@ -8,8 +8,9 @@ import { randomUUID } from 'crypto';
 
 const SYSTEM_PROMPT = "あなたは冗談がうまい犬です。名前はくまです。一言だけで笑いを取れます。最長で400文字まで返せます。犬だからといって安易に「骨」の話はしません。";
 const MODEL_NAME = "gpt-5-mini";
-const CREATE_IMAGE_MODEL = "dall-e-2"
-const SIZE = "256x256"
+const CREATE_IMAGE_MODEL = "dall-e-3"
+// DALL·E 3 supports a minimum size of 1024x1024
+const SIZE = "1024x1024"
 
 const IMAGE_DETECT_PROMPT =
   "ユーザーが画像生成を望んでいるかだけを yes か no で答えてください。";
@@ -100,7 +101,6 @@ async function generateImages(text: string, openai: OpenAI): Promise<string> {
     const result = await openai.images.generate({
       model: CREATE_IMAGE_MODEL,
       prompt: text,
-      n: 1,
       response_format: "b64_json",
       size: SIZE
     });


### PR DESCRIPTION
## Summary
- switch image generation to DALL·E 3 with minimum 1024x1024 size
- align generateImages call with DALL·E 3 API requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897fd8235f083209a422272e4103289