### PR TITLE
fix: CloudWatchメトリクスフィルターパターンを修正

### DIFF
--- a/lib/line-bot-cdk.ts
+++ b/lib/line-bot-cdk.ts
@@ -130,7 +130,7 @@ export class LineBotCdk extends Construct {
       logGroup: lineBotFunction.logGroup,
       metricNamespace: 'LineBot/OpenAI',
       metricName: 'OpenAIErrors',
-      filterPattern: logs.FilterPattern.literal('[OPENAI_ERROR]'),
+      filterPattern: logs.FilterPattern.literal('"[OPENAI_ERROR]"'),
       metricValue: '1',
       defaultValue: 0
     });


### PR DESCRIPTION
- literal('[OPENAI_ERROR]') → literal('"[OPENAI_ERROR]"')
- フィールド分割パターンから文字列検索パターンに変更
- これによりOpenAI APIエラーログが正しく検出される
- SNS通知が適切に動作するようになる

闘魂デバッグにより根本原因を特定・解決