### PR TITLE
Update OpenAI model constant to gpt-5.4-nano

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -8,7 +8,7 @@ import {
   RECENT_SUMMARY_LIMIT,
 } from './types';
 
-export const MODEL_NAME = 'gpt-5-nano';
+export const MODEL_NAME = 'gpt-5.4-nano';
 export const SUMMARY_MODEL_NAME = MODEL_NAME;
 export const CREATE_IMAGE_MODEL = 'gpt-image-1.5';
 export const IMAGE_SIZE = '1024x1024';


### PR DESCRIPTION
### Motivation
- Switch the configured OpenAI model to `gpt-5.4-nano` so the bot uses the desired newer model for replies and summaries.

### Description
- Updated the `MODEL_NAME` constant in `lib/prompts.ts` from `'gpt-5-nano'` to `'gpt-5.4-nano'`, while `SUMMARY_MODEL_NAME` remains aliased to `MODEL_NAME`.

### Testing
- Ran `npm run build` and the TypeScript build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c237201af08320b29fc5cf9a0d4194)