### PR TITLE
Switch image generation to Gemini API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Lambda Function URL
         |
         v
 AWS Lambda (TypeScript)
-  |- SSM Parameter Store (LINE/OpenAI secrets)
+  |- SSM Parameter Store (LINE/OpenAI/Gemini secrets)
   |- DynamoDB (short conversation memory)
   |- OpenAI Responses API (text reply + memory summary)
-  |- OpenAI Images API
+  |- Gemini Image Generation API
   `- S3 (generated images, 7-day lifecycle)
 
 CloudWatch Logs / Metric Filter / Alarm
@@ -31,7 +31,7 @@ SNS Email Notification
 - LINE webhookをLambda Function URLで受け取る
 - LINE署名を検証する
 - テキスト会話ではOpenAIに問い合わせて、くまの人格で短く返答する
-- 画像依頼では、くま画伯として画像を生成して返す
+- 画像依頼では、Geminiでくま画伯として画像を生成して返す
 - ユーザーごとに短い会話メモをDynamoDBへ保存する
 - Lambda / OpenAIエラーをCloudWatch + SNSで通知する
 
@@ -87,6 +87,7 @@ CDK実行時に以下を設定します。
 export CHANNEL_SECRET_PARAM_NAME="/line-bot/kuma/channelSecret"
 export CHANNEL_ACCESS_TOKEN_PARAM_NAME="/line-bot/kuma/channelAccessToken"
 export OPENAI_API_KEY_PARAM_NAME="/line-bot/kuma/OpenAIAPIKEY"
+export GEMINI_API_KEY_PARAM_NAME="/line-bot/kuma/GeminiAPIKEY"
 export EMAIL_ADDRESS="your-alert@example.com"
 ```
 
@@ -97,6 +98,7 @@ Lambdaには以下が設定されます。
 - `CHANNEL_SECRET_PARAM_NAME`
 - `CHANNEL_ACCESS_TOKEN_PARAM_NAME`
 - `OPENAI_API_KEY_PARAM_NAME`
+- `GEMINI_API_KEY_PARAM_NAME`
 - `IMAGES_BUCKET_NAME`
 - `CONVERSATION_MEMORY_TABLE_NAME`
 
@@ -120,6 +122,12 @@ aws ssm put-parameter \
 aws ssm put-parameter \
   --name "/line-bot/kuma/OpenAIAPIKEY" \
   --value "your-openai-api-key" \
+  --type "SecureString" \
+  --overwrite
+
+aws ssm put-parameter \
+  --name "/line-bot/kuma/GeminiAPIKEY" \
+  --value "your-gemini-api-key" \
   --type "SecureString" \
   --overwrite
 ```

--- a/lib/line-bot-cdk.function.ts
+++ b/lib/line-bot-cdk.function.ts
@@ -242,11 +242,12 @@ async function generateImages(
   geminiApiKey: string
 ): Promise<string> {
   try {
-    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${CREATE_IMAGE_MODEL}:generateContent?key=${geminiApiKey}`;
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${CREATE_IMAGE_MODEL}:generateContent`;
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'x-goog-api-key': geminiApiKey,
       },
       body: JSON.stringify({
         contents: [

--- a/lib/line-bot-cdk.function.ts
+++ b/lib/line-bot-cdk.function.ts
@@ -35,6 +35,7 @@ import {
 interface Clients {
   lineClient: line.messagingApi.MessagingApiClient;
   openaiClient: OpenAI;
+  geminiApiKey: string;
   channelSecret: string;
 }
 
@@ -71,10 +72,11 @@ async function getParameter(name: string): Promise<string> {
 }
 
 async function loadClients(): Promise<Clients> {
-  const [channelSecret, channelAccessToken, openAIAPIKey] = await Promise.all([
+  const [channelSecret, channelAccessToken, openAIAPIKey, geminiApiKey] = await Promise.all([
     getParameter(process.env.CHANNEL_SECRET_PARAM_NAME!),
     getParameter(process.env.CHANNEL_ACCESS_TOKEN_PARAM_NAME!),
     getParameter(process.env.OPENAI_API_KEY_PARAM_NAME!),
+    getParameter(process.env.GEMINI_API_KEY_PARAM_NAME!),
   ]);
 
   return {
@@ -82,6 +84,7 @@ async function loadClients(): Promise<Clients> {
       channelAccessToken,
     }),
     openaiClient: new OpenAI({ apiKey: openAIAPIKey }),
+    geminiApiKey,
     channelSecret,
   };
 }
@@ -236,30 +239,61 @@ async function summarizeConversationMemory(
 async function generateImages(
   text: string,
   context: ConversationMemoryContext,
-  openai: OpenAI
+  geminiApiKey: string
 ): Promise<string> {
   try {
-    const result = await openai.images.generate({
-      model: CREATE_IMAGE_MODEL,
-      prompt: buildImagePrompt(text, context),
-      size: IMAGE_SIZE,
-      quality: 'medium',
+    const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${CREATE_IMAGE_MODEL}:generateContent?key=${geminiApiKey}`;
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: buildImagePrompt(text, context) }],
+          },
+        ],
+        generationConfig: {
+          responseModalities: ['Image'],
+        },
+      }),
     });
 
-    const imageData = result.data?.[0]?.b64_json;
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Gemini image generation failed: ${response.status} ${errorText}`);
+    }
+
+    const result = (await response.json()) as {
+      candidates?: Array<{
+        content?: {
+          parts?: Array<{ inlineData?: { data?: string; mimeType?: string } }>;
+        };
+      }>;
+    };
+
+    const imagePart = result.candidates
+      ?.flatMap((candidate) => candidate.content?.parts ?? [])
+      .find((part) => part.inlineData?.data);
+
+    const imageData = imagePart?.inlineData?.data;
     if (!imageData) {
       throw new Error('画像生成に失敗しました');
     }
 
     const imageBuffer = Buffer.from(imageData, 'base64');
-    const fileName = `${randomUUID()}.png`;
+    const contentType = imagePart?.inlineData?.mimeType ?? 'image/png';
+    const extension = contentType === 'image/jpeg' ? 'jpg' : 'png';
+    const fileName = `${randomUUID()}.${extension}`;
 
     await s3Client.send(
       new PutObjectCommand({
         Bucket: process.env.IMAGES_BUCKET_NAME,
         Key: fileName,
         Body: imageBuffer,
-        ContentType: 'image/png',
+        ContentType: contentType,
       })
     );
 
@@ -272,7 +306,7 @@ async function generateImages(
       expiresIn: 60 * 60 * 24 * 7,
     });
   } catch (error) {
-    console.error('OpenAI image generation error', { error, prompt: text });
+    console.error('Gemini image generation error', { error, prompt: text });
     logOpenAIError('ImageAPI', error, text);
     throw error;
   }
@@ -353,7 +387,7 @@ async function handleTextMessageEvent(
       const imageUrl = await generateImages(
         ev.message.text,
         context,
-        clients.openaiClient
+        clients.geminiApiKey
       );
       const replySent = await sendImageReply(
         clients.lineClient,

--- a/lib/line-bot-cdk.ts
+++ b/lib/line-bot-cdk.ts
@@ -20,6 +20,7 @@ export class LineBotCdk extends Construct {
       'CHANNEL_SECRET_PARAM_NAME',
       'CHANNEL_ACCESS_TOKEN_PARAM_NAME', 
       'OPENAI_API_KEY_PARAM_NAME',
+      'GEMINI_API_KEY_PARAM_NAME',
       'EMAIL_ADDRESS'
     ];
 
@@ -69,6 +70,7 @@ export class LineBotCdk extends Construct {
         CHANNEL_SECRET_PARAM_NAME: process.env.CHANNEL_SECRET_PARAM_NAME || '',
         CHANNEL_ACCESS_TOKEN_PARAM_NAME: process.env.CHANNEL_ACCESS_TOKEN_PARAM_NAME || '',
         OPENAI_API_KEY_PARAM_NAME: process.env.OPENAI_API_KEY_PARAM_NAME || '',
+        GEMINI_API_KEY_PARAM_NAME: process.env.GEMINI_API_KEY_PARAM_NAME || '',
         IMAGES_BUCKET_NAME: imagesBucket.bucketName, // バケット名を環境変数に追加
         CONVERSATION_MEMORY_TABLE_NAME: conversationMemoryTable.tableName,
       },
@@ -85,6 +87,7 @@ export class LineBotCdk extends Construct {
         `arn:aws:ssm:*:*:parameter${process.env.CHANNEL_SECRET_PARAM_NAME}`,
         `arn:aws:ssm:*:*:parameter${process.env.CHANNEL_ACCESS_TOKEN_PARAM_NAME}`,
         `arn:aws:ssm:*:*:parameter${process.env.OPENAI_API_KEY_PARAM_NAME}`,
+        `arn:aws:ssm:*:*:parameter${process.env.GEMINI_API_KEY_PARAM_NAME}`,
       ],
     });
 

--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -10,7 +10,7 @@ import {
 
 export const MODEL_NAME = 'gpt-5.4-nano';
 export const SUMMARY_MODEL_NAME = MODEL_NAME;
-export const CREATE_IMAGE_MODEL = 'gpt-image-1.5';
+export const CREATE_IMAGE_MODEL = 'gemini-3-pro-image-preview';
 export const IMAGE_SIZE = '1024x1024';
 export const OPENAI_FALLBACK_MESSAGE =
   'ちょっと調子が悪いみたい。また少ししてから話しかけてください。';

--- a/test/line-bot-cdk.test.ts
+++ b/test/line-bot-cdk.test.ts
@@ -11,6 +11,7 @@ test('Stack has a Lambda function and conversation memory table', () => {
   process.env.CHANNEL_SECRET_PARAM_NAME = 'dummySecretParam';
   process.env.CHANNEL_ACCESS_TOKEN_PARAM_NAME = 'dummyAccessTokenParam';
   process.env.OPENAI_API_KEY_PARAM_NAME = 'dummyOpenAIApiKeyParam';
+  process.env.GEMINI_API_KEY_PARAM_NAME = 'dummyGeminiApiKeyParam';
   process.env.EMAIL_ADDRESS = 'test@example.com';
   const stack = new LineBotCdkStack(app, 'TestStack');
   const template = Template.fromStack(stack);


### PR DESCRIPTION
### Motivation

- Replace the existing OpenAI Images pipeline with Google Gemini image generation using the `gemini-3-pro-image-preview` model and request images only via `responseModalities: ['Image']` to match the new API and desired modality.
- Keep the existing S3 upload / pre-signed URL delivery flow while moving actual image generation requests to Google so text chat and memory summarization remain on OpenAI.

### Description

- Changed the image model constant to `gemini-3-pro-image-preview` (`CREATE_IMAGE_MODEL`) in `lib/prompts.ts`.
- Replaced the `generateImages` implementation in `lib/line-bot-cdk.function.ts` to call the Google Generative Language endpoint (`/v1beta/models/...:generateContent`) with `generationConfig.responseModalities: ['Image']`, extract base64 `inlineData`, set content-type from the response, and upload the image to S3 (existing behavior preserved).
- Added `geminiApiKey` to the runtime `Clients`, load it from SSM using a new parameter name `GEMINI_API_KEY_PARAM_NAME`, and wired that through the CDK construct and Lambda environment variables.
- Updated CDK (`lib/line-bot-cdk.ts`) to require `GEMINI_API_KEY_PARAM_NAME`, inject it into the Lambda environment, and include it in the `ssm:GetParameter` IAM resource list, and updated `README.md` and unit test fixture to document and handle the new parameter.

### Testing

- Built the project with `npm run build` and the TypeScript compile succeeded.
- Ran unit tests with `npm test`; after adding a dummy `GEMINI_API_KEY_PARAM_NAME` to the test fixture the test suite passed (`3 passed`).
- All automated checks in the local CI runs reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f87e3b8b0883208e27de65cc99a07b)