### PR TITLE
Update GitHub Actions: add GEMINI env, bump Node to 24, and upgrade AWS creds action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
       CHANNEL_SECRET_PARAM_NAME: ${{ vars.CHANNEL_SECRET_PARAM_NAME }}
       CHANNEL_ACCESS_TOKEN_PARAM_NAME: ${{ vars.CHANNEL_ACCESS_TOKEN_PARAM_NAME }}
       OPENAI_API_KEY_PARAM_NAME: ${{ vars.OPENAI_API_KEY_PARAM_NAME }}
+      GEMINI_API_KEY_PARAM_NAME: ${{ vars.GEMINI_API_KEY_PARAM_NAME }}
       EMAIL_ADDRESS: ${{ vars.EMAIL_ADDRESS }}
 
     steps:
@@ -23,10 +24,10 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,13 @@ jobs:
       CHANNEL_SECRET_PARAM_NAME: ${{ vars.CHANNEL_SECRET_PARAM_NAME }}
       CHANNEL_ACCESS_TOKEN_PARAM_NAME: ${{ vars.CHANNEL_ACCESS_TOKEN_PARAM_NAME }}
       OPENAI_API_KEY_PARAM_NAME: ${{ vars.OPENAI_API_KEY_PARAM_NAME }}
+      GEMINI_API_KEY_PARAM_NAME: ${{ vars.GEMINI_API_KEY_PARAM_NAME }}
       EMAIL_ADDRESS: ${{ vars.EMAIL_ADDRESS }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
### Motivation
- Add a new `GEMINI_API_KEY_PARAM_NAME` environment variable for Gemini integration and bring CI/deploy runtimes and actions up to date for compatibility and security. 

### Description
- Added `GEMINI_API_KEY_PARAM_NAME` to environment variables in both `.github/workflows/deploy.yml` and `.github/workflows/test.yml`.
- Bumped `node-version` from `22` to `24` in both workflows to use the newer Node.js runtime.
- Upgraded `aws-actions/configure-aws-credentials` to `aws-actions/configure-aws-credentials@v6.1.0` in `deploy.yml`.

### Testing
- No automated tests were executed as part of this change; the `Node.js CI` workflow is configured to run `npm ci` and `npm test` and the deploy workflow runs the build and `cdk` steps when triggered by CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f886b9fbe08320aacd3e8e1301f2f1)