### PR TITLE
Update image generation model to gemini-3.1-flash-image-preview

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -10,7 +10,7 @@ import {
 
 export const MODEL_NAME = 'gpt-5.4-nano';
 export const SUMMARY_MODEL_NAME = MODEL_NAME;
-export const CREATE_IMAGE_MODEL = 'gemini-3-pro-image-preview';
+export const CREATE_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
 export const IMAGE_SIZE = '1024x1024';
 export const OPENAI_FALLBACK_MESSAGE =
   'ちょっと調子が悪いみたい。また少ししてから話しかけてください。';


### PR DESCRIPTION
### Motivation
- Use the newer Gemini image-preview model for image generation by switching the configured model constant to `gemini-3.1-flash-image-preview`.

### Description
- Replace the `CREATE_IMAGE_MODEL` value in `lib/prompts.ts` from `gemini-3-pro-image-preview` to `gemini-3.1-flash-image-preview` (single-line constant update).

### Testing
- No automated runtime tests were run because this is a trivial constant change; validation was limited to a source file update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f890f9ee608320abc41c4e86bbfb88)