### PR TITLE
Refine image prompt to produce single visual-scene artwork

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -85,7 +85,7 @@ export function buildImagePrompt(
     context.userMemory && context.userMemory.open_loops.length > 0 &&
       `このユーザーと続いている話題: ${context.userMemory.open_loops.join(' / ')}`,
     `今回の依頼: ${text}`,
-    '上の文脈を踏まえて、一貫した内容の画像を1枚描いてください。',
+    '上の文脈を踏まえて、ユーザーの依頼を【視覚的な情景】に変換し、一枚の絵として描画してください。文字や吹き出しは極力入れず、アート作品として仕上げてください。',
   ].filter(Boolean);
 
   return sections.join('\n');


### PR DESCRIPTION
### Motivation
- Clarify the image-generation instruction so the assistant converts user requests into a single, artwork-style visual scene and minimizes text or speech bubbles.

### Description
- In `lib/prompts.ts` update the final line of `buildImagePrompt` to instruct: convert the user's request into a single visual scene and render one art-focused image with minimal text/balloons.

### Testing
- No automated tests were run because this change is a single prompt string update only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f89b5d34f483208198bddb4105c0a7)