### PR TITLE
Switch GitHub Actions deploy to OIDC role and add id-token permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
       - main  # 任意のブランチでOK
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -29,9 +33,11 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
+
+      - name: Verify AWS identity
+        run: aws sts get-caller-identity
 
       - uses: flatt-security/setup-takumi-guard-npm@v1
 


### PR DESCRIPTION
### Motivation
- Replace long-lived AWS access keys with an OIDC role assumption to improve security and follow best practices.
- Ensure the workflow can request an ID token from GitHub for AWS role assumption by granting the necessary permissions.

### Description
- Added top-level `permissions` with `id-token: write` and `contents: read` to allow OIDC-based authentication.
- Updated the `aws-actions/configure-aws-credentials` step to use `role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}` instead of static `aws-access-key-id` and `aws-secret-access-key` secrets.
- Added a verification step that runs `aws sts get-caller-identity` to confirm the assumed identity before deployment.
- Left the remaining build and `cdk` steps intact (`npm ci`, `npm run build`, `cdk synth`, `cdk deploy`, `cdk gc`).

### Testing
- No automated tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8a67d78088320bd3eabfa10e97a7b)