### PR TITLE
Remove CDK bootstrap from CI deploy workflow and document bootstrap requirement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Install AWS CDK CLI
         run: npm install -g aws-cdk
 
-      - name: Bootstrap CDK (if first time)
-        run: cdk bootstrap
-
       - name: Build TypeScript code
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ cdk synth
 cdk deploy
 ```
 
+> [!NOTE]
+> GitHub Actions の `deploy` workflow は、デプロイ先AWS環境で `cdk bootstrap` が事前に完了していることを前提にしています。  
+> CI では `cdk bootstrap` を実行しないため、未bootstrap環境へ初回デプロイする場合はローカル等で先に `cdk bootstrap` を実行してください。
+
 デプロイ後、CloudFormation Outputsに少なくとも以下が表示されます。
 
 - `FunctionUrl`


### PR DESCRIPTION
### Motivation

- Avoid running account-level `cdk bootstrap` from the GitHub Actions `deploy` workflow so CI does not perform initial environment provisioning.
- Make the bootstrap expectation explicit in the documentation so first-time deployers know to run `cdk bootstrap` locally.

### Description

- Removed the `Bootstrap CDK (if first time)` step that ran `cdk bootstrap` from `.github/workflows/deploy.yml`.
- Added a note to `README.md` stating that the GitHub Actions `deploy` workflow expects the target AWS environment to be pre-bootstrapped and advising to run `cdk bootstrap` locally for initial deployment.

### Testing

- Ran `npm run build` locally and the build completed successfully.
- Ran `npm test` and `cdk synth` locally and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8aa1bf72c8320a3ab5236be9c9f0a)