### PR TITLE
Use gemini-2.5-flash-image for image generation

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -10,7 +10,7 @@ import {
 
 export const MODEL_NAME = 'gpt-5.4-nano';
 export const SUMMARY_MODEL_NAME = MODEL_NAME;
-export const CREATE_IMAGE_MODEL = 'gemini-3.1-flash-image-preview';
+export const CREATE_IMAGE_MODEL = 'gemini-2.5-flash-image';
 export const IMAGE_SIZE = '1024x1024';
 export const OPENAI_FALLBACK_MESSAGE =
   'ちょっと調子が悪いみたい。また少ししてから話しかけてください。';


### PR DESCRIPTION
### Motivation
- Replace the preview image model with a stable image model constant to control which model is used for image generation (`gemini-2.5-flash-image`).

### Description
- Updated `CREATE_IMAGE_MODEL` in `lib/prompts.ts` from `'gemini-3.1-flash-image-preview'` to `'gemini-2.5-flash-image'`.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ba6154e483209d1d7dd0afb30ded)