### PR TITLE
Update image model to gemini-3-pro-image-preview

### DIFF
--- a/lib/prompts.ts
+++ b/lib/prompts.ts
@@ -10,7 +10,7 @@ import {
 
 export const MODEL_NAME = 'gpt-5.4-nano';
 export const SUMMARY_MODEL_NAME = MODEL_NAME;
-export const CREATE_IMAGE_MODEL = 'gemini-2.5-flash-image';
+export const CREATE_IMAGE_MODEL = 'gemini-3-pro-image-preview';
 export const IMAGE_SIZE = '1024x1024';
 export const OPENAI_FALLBACK_MESSAGE =
   'ちょっと調子が悪いみたい。また少ししてから話しかけてください。';


### PR DESCRIPTION
### Motivation
- Use the requested image generation model `gemini-3-pro-image-preview` instead of the previous `gemini-2.5-flash-image` for image creation.

### Description
- Changed the `CREATE_IMAGE_MODEL` constant in `lib/prompts.ts` from `gemini-2.5-flash-image` to `gemini-3-pro-image-preview`.

### Testing
- No automated tests were run because this is a constant-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f92feb2de483208fe79b11d6d26ea3)