### PR TITLE
Use v6 tag for aws-actions/configure-aws-credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '24'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v6.1.0
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1


### PR DESCRIPTION
### Motivation
- Prefer the floating major-version tag like `actions/checkout@v6` and `actions/setup-node@v6` so the workflow follows the same style and receives non-breaking fixes within v6.

### Description
- Replace `aws-actions/configure-aws-credentials@v6.1.0` with `aws-actions/configure-aws-credentials@v6` in `.github/workflows/deploy.yml` and commit the change.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml')"` (passed), `git diff --check` (passed), and `git ls-remote --tags https://github.com/aws-actions/configure-aws-credentials.git refs/tags/v6 refs/tags/v6.2.0` (confirmed `v6` exists and dereferences to the same commit as `v6.2.0`), and a `python` YAML parse attempt was skipped due to missing `PyYAML`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f8680c0c0832085562ffea25036e3)