### PR TITLE
chore(dependabot): configure private npm registry for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,15 @@
 version: 2
+registries:
+  takumi_guard_npm:
+    type: npm-registry
+    url: https://npm.flatt.tech/
+    token: ${{secrets.TAKUMI_GUARD_TOKEN}}
 
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    registries:
+      - takumi_guard_npm
     schedule:
       interval: "weekly"
     cooldown:


### PR DESCRIPTION
Add the `takumi_guard_npm` registry to allow Dependabot to fetch package updates from the private registry.

- Define a custom npm registry pointing to `https://npm.flatt.tech/` using `TAKUMI_GUARD_TOKEN`
- Configure the npm ecosystem block to use the newly registered registry